### PR TITLE
Support Sabbath Mode in Samsung Refrigerator

### DIFF
--- a/Drivers/ReplicaSamsungRefrigerator.groovy
+++ b/Drivers/ReplicaSamsungRefrigerator.groovy
@@ -25,7 +25,7 @@ import org.json.JSONObject
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 
-def driverVer() { return "1.0-1" }
+def driverVer() { return "1.0-2" }
 def appliance() { return "ReplicaSamsungRefrigerator" }
 
 metadata {
@@ -64,6 +64,11 @@ metadata {
 		attribute "waterFilterStatus", "string"
 		attribute "waterFilterUsage", "string"
 		command "resetWaterFilter"
+		//	sabbathMode
+		capability "Sabbath Mode"
+		attribute "status", "string"
+		command "setSabbathMode", [[ name: "Sabbath Mode", constraints: ["on", "off"], type: "ENUM"]]
+
 	}
 	preferences {
 	}
@@ -176,7 +181,8 @@ def designCapabilities() {
 	return [
 		"contactSensor", "refresh", "refrigeration", "temperatureMeasurement",
 		"thermostatCoolingSetpoint", "custom.deodorFilter", "custom.fridgeMode",
-		"custom.waterFilter", "samsungce.powerCool", "samsungce.powerFreeze"
+		"custom.waterFilter", "samsungce.powerCool", "samsungce.powerFreeze", 
+		"samsungce.sabbathMode"
 	]
 }
 
@@ -418,6 +424,14 @@ def resetWaterFilter() {
 		logInfo("resetWaterFilter")
 	} else {
 		logWarn("resetWaterFilter: Device does not support resetWaterFilter")
+	}
+}
+
+//	===== Sabbath Mode
+def setSabbathMode(onOff) {
+	if (state.deviceCapabilities.contains("samsungce.sabbathMode")) {
+		sendRawCommand("main", "samsungce.sabbathMode", onOff)
+		logInfo("setSabbathMode: ${onOff}")
 	}
 }
 

--- a/Drivers/ReplicaSamsungRefrigerator.groovy
+++ b/Drivers/ReplicaSamsungRefrigerator.groovy
@@ -17,6 +17,8 @@ Changes:
 a.	Changed link to help file.
 b.	Added logging prefs to library logging.
 d.	Changed sendRawCommand to use dataValue replica vice description.
+1.0-2:
+a.	Added support for sabbath mode
 
 Issues with this driver: Contact davegut via Private Message on the
 Hubitat Community site: https://community.hubitat.com/

--- a/Drivers/ReplicaSamsungRefrigerator.groovy
+++ b/Drivers/ReplicaSamsungRefrigerator.groovy
@@ -65,10 +65,8 @@ metadata {
 		attribute "waterFilterUsage", "string"
 		command "resetWaterFilter"
 		//	sabbathMode
-		capability "Sabbath Mode"
-		attribute "status", "string"
+		attribute "sabbathMode", "string"
 		command "setSabbathMode", [[ name: "Sabbath Mode", constraints: ["on", "off"], type: "ENUM"]]
-
 	}
 	preferences {
 	}
@@ -290,6 +288,13 @@ def parseEvent(event) {
 					parseCorrect([capability: event.capability, attribute: attribute, 
 								  value: event.value, unit: event.unit])
 					break
+                case "status":
+                    def attribute = "sabbathMode"
+                    if (event.capability == "samsungce.sabbathMode") {
+                        parseCorrect([capability: event.capability, attribute: attribute,
+                                      value: event.value, unit: event.unit])
+                    }
+                    break
 				case "deodorFilterLastResetDate":
 				case "deodorFilterCapacity":
 				case "deodorFilterResetType":


### PR DESCRIPTION
# Summary
Adds a sabbath mode status and a setSabbathMode command to the Samsung refrigerator parent device.

# Motivation
Sabbath mode is a feature on many appliances that allows them to use devices on the Sabbath and holidays.  (For example, it disables the interior light from turning on when the refrigerator door is opened.  If not for that, opening the door would constitute a prohibited type of work on the Sabbath.)  On most fridges with this feature, it can be enabled and disabled manually.  In addition, it can be enabled and disabled in the Smartthings app.

This change allows the Sabbath mode status to be reported in Hubitat, and for it to be enabled and disabled via Hubitat.  This allows for rules to automate this change, e.g. based on [Sabbath/Holiday Mode Scheduler](https://github.com/dds82/shabbat).  Automation is far less error-prone, and removes a weekly checklist item that must be performed on a busy pre-Sabbath Friday afternoon.

# Changes
This PR adds a sabbathMode attribute to the parent SamsungRefigerator device.  This attribute is updated when Hubithing propagates a Smartthings sabbathMode attribute change to Hubitat.  In addition, it adds a setSabbathMode command to the device which accepts parameters of "on" or "off".

# Design
I took a similar approach to that used by the power cool and power freeze features.

## Potential Issues
This may not be the ideal method of making this feature available, since it limits automation to using Rule Machine so that rules may use custom actions.  These commands do not show up in e.g. Basic Rules or Simple Rules, and even in Rule Machine, one has to choose an unlrelated capability (e.g. Temperature) in order to send a Sabbath mode command.

## Alternate Approach
A more straightforward approach might be to add a Sabbath Mode child device, which can then present a switch capability to Hubitat.  This would have the advantage of working with any app and dashboard.  The disadvantage is that unless I'm mistaken, this would then have to be created for all users, whether or not they every need to enable or disable Sabbath mode.  Given that a modern Samsung fridge already can create a fair number of child devices (e.g. one each for each ice maker), this might be a better approach.  What I've contributed here is sufficient for my own automation needs, and so I'm happy to keep it as is.  But if there is a preference for the other approach, I'm open to trying it out.